### PR TITLE
Adjust zoom

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -6,8 +6,7 @@ const map = new mapbox.Map({
   container: "map",
   style: "mapbox://styles/housingstudies/cmcb0c6ql002001rz02zqewvm",
   center: [-87.66231, 41.85754], // [lng, lat]
-  zoom: 13, // parcels will not be visible below 13
-  minZoom: 13,
+  zoom: 9, // parcels will not be visible below 9
 })
 
 // Zoom and rotation controls

--- a/js/map.js
+++ b/js/map.js
@@ -6,7 +6,8 @@ const map = new mapbox.Map({
   container: "map",
   style: "mapbox://styles/housingstudies/cmcb0c6ql002001rz02zqewvm",
   center: [-87.66231, 41.85754], // [lng, lat]
-  zoom: 9, // parcels will not be visible below 9
+  zoom: 12, // parcels will not be visible below 12
+  minZoom: 12,
 })
 
 // Zoom and rotation controls


### PR DESCRIPTION
## Overview

Quick adjustment to zoom levels after experimenting with generating our own tilesets. The minzoom has been removed, and the default zoom is now set at the farthest point our map allows.

This map was generated using the command: `tippecanoe -o ihs-cook-parcels-2024.mbtiles -Z 9 -z 16 ihs-cook-parcels-2024.geojson --detect-shared-borders --simplification=10 --drop-smallest-as-needed`

- Connects #3 

## Testing Instructions

- Head to the preview, and confirm that the features we have showing in the associated mapbox style appear there
