### PR TITLE
removed opacity change on hover, using border color for highlight

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -19,7 +19,6 @@ const map = new mapbox.Map({
 
 // Zoom and rotation controls
 map.addControl(new mapbox.NavigationControl(), "top-left")
-map.scrollZoom.disable()
 
 // Attribution
 const attributionStr = "IHS Calculations of Data from the Cook County Assessor"
@@ -64,16 +63,7 @@ map.on("load", () => {
     "source-layer": "ihs_rollup_adjusted-9njcx3",
     paint: {
       "fill-color": "#749C75",
-      "fill-opacity": [
-        "case",
-        [
-          "any",
-          ["boolean", ["feature-state", "hover"], false],
-          ["boolean", ["feature-state", "selected"], false],
-        ],
-        0.3,
-        0,
-      ],
+      "fill-opacity": 0,
     },
   })
 
@@ -84,11 +74,24 @@ map.on("load", () => {
       source: "ihs_rollup_source",
       "source-layer": "ihs_rollup_adjusted-9njcx3",
       paint: {
-        "line-color": "#000000",
+        "line-color": [
+          "case",
+          [
+            "any",
+            ["boolean", ["feature-state", "hover"], false],
+            ["boolean", ["feature-state", "selected"], false],
+          ],
+          "#C1C176",
+          "#000000",
+        ],
         "line-width": [
           "case",
-          ["boolean", ["feature-state", "selected"], false],
-          5,
+          [
+            "any",
+            ["boolean", ["feature-state", "hover"], false],
+            ["boolean", ["feature-state", "selected"], false],
+          ],
+          4,
           1,
         ],
       },


### PR DESCRIPTION
## Overview

In using the housing composition map, the fill opacity on hover and click gets in the way of looking at detailed areas of a specific selected area. This change removes the fill opacity and replaces it with a border highlight instead.

Also, because this is a full screen map, it is ok to enable scroll wheel zoom.

### Demo

<img width="1896" height="968" alt="Screenshot 2026-03-11 at 11 50 44 AM" src="https://github.com/user-attachments/assets/f603602c-7dff-434d-9ac7-842bc16cd559" />


## Testing Instructions

- click and hover around on the map to and confirm functionality works as expected still
